### PR TITLE
We can not prefer f5121 anymore in prjconf.

### DIFF
--- a/prjconf/prjconf.xml
+++ b/prjconf/prjconf.xml
@@ -1,4 +1,3 @@
 # device-specific project conf:
-Prefer: droid-config-f5121-bluez5
 Prefer: droid-glibc-tools
 


### PR DESCRIPTION
[prjconf] Drop explicit prefer for f512x. Contributes to JB#41311

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>